### PR TITLE
Chore: update `repository` field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,7 @@
     "release": "eslint-release",
     "ci-release": "eslint-ci-release"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/eslint/eslint-visitor-keys.git"
-  },
+  "repository": "eslint/eslint-visitor-keys",
   "keywords": [],
   "author": "Toru Nagashima (https://github.com/mysticatea)",
   "license": "Apache-2.0",


### PR DESCRIPTION
Because of https://github.com/eslint/eslint-release/blob/2731ce15055ce6649c735883b011b4dfc95c15a1/lib/release-ops.js#L67