### PR TITLE
Breaking: update keys

### DIFF
--- a/lib/visitor-keys.json
+++ b/lib/visitor-keys.json
@@ -151,9 +151,6 @@
     "JSXExpressionContainer": [
         "expression"
     ],
-    "JSXSpreadChild": [
-        "expression"
-    ],
     "JSXIdentifier": [],
     "JSXMemberExpression": [
         "object",
@@ -176,8 +173,6 @@
         "children",
         "closingFragment"
     ],
-    "JSXOpeningFragment": [],
-    "JSXClosingFragment": [],
     "Literal": [],
     "LabeledStatement": [
         "label",

--- a/lib/visitor-keys.json
+++ b/lib/visitor-keys.json
@@ -129,6 +129,49 @@
         "imported",
         "local"
     ],
+    "JSXAttribute": [
+        "name",
+        "value"
+    ],
+    "JSXClosingElement": [
+        "name"
+    ],
+    "JSXElement": [
+        "openingElement",
+        "children",
+        "closingElement"
+    ],
+    "JSXEmptyExpression": [],
+    "JSXExpressionContainer": [
+        "expression"
+    ],
+    "JSXSpreadChild": [
+        "expression"
+    ],
+    "JSXIdentifier": [],
+    "JSXMemberExpression": [
+        "object",
+        "property"
+    ],
+    "JSXNamespacedName": [
+        "namespace",
+        "name"
+    ],
+    "JSXOpeningElement": [
+        "name",
+        "attributes"
+    ],
+    "JSXSpreadAttribute": [
+        "argument"
+    ],
+    "JSXText": [],
+    "JSXFragment": [
+        "openingFragment",
+        "children",
+        "closingFragment"
+    ],
+    "JSXOpeningFragment": [],
+    "JSXClosingFragment": [],
     "Literal": [],
     "LabeledStatement": [
         "label",

--- a/lib/visitor-keys.json
+++ b/lib/visitor-keys.json
@@ -60,7 +60,6 @@
         "label"
     ],
     "DebuggerStatement": [],
-    "DirectiveStatement": [],
     "DoWhileStatement": [
         "body",
         "test"
@@ -151,7 +150,6 @@
         "key",
         "value"
     ],
-    "ModuleSpecifier": [],
     "NewExpression": [
         "callee",
         "arguments"

--- a/lib/visitor-keys.json
+++ b/lib/visitor-keys.json
@@ -83,6 +83,12 @@
     "ExpressionStatement": [
         "expression"
     ],
+    "ExperimentalRestProperty": [
+        "argument"
+    ],
+    "ExperimentalSpreadProperty": [
+        "argument"
+    ],
     "ForStatement": [
         "init",
         "test",


### PR DESCRIPTION
I realized some keys are extra and some keys are lacking.
This PR fixes the problem.

- This removes `DirectiveStatement` and `ModuleSpecifier`. The two are not a part of ESTree. We are not using those.
- This adds JSX stuff. I copied those from [babel-types/src/definitions/jsx.js](https://github.com/babel/babel/blob/master/packages/babel-types/src/definitions/jsx.js) and checked in [acorn-jsx/inject.js](https://github.com/RReverser/acorn-jsx/blob/1dc3245e5dc135a1f542e0ab2e959b97d2316d72/inject.js).
- This adds `ExperimentalRestProperty` and `ExperimentalSpreadProperty`.

This PR includes deletion, so I marked this as `Breaking:`.