### PR TITLE
Upgrade: eslint-release@1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /coverage
 /node_modules
 /test.*
+.eslint-release-info.json

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "eslint": "^4.7.2",
     "eslint-config-eslint": "^4.0.0",
-    "eslint-release": "^0.10.3",
+    "eslint-release": "^1.0.0",
     "mocha": "^3.5.3",
     "nyc": "^11.2.1",
     "opener": "^1.4.3"
@@ -23,8 +23,11 @@
     "pretest": "npm run -s lint",
     "test": "nyc mocha tests/lib",
     "coverage": "nyc report --reporter lcov && opener coverage/lcov-report/index.html",
-    "release": "eslint-release",
-    "ci-release": "eslint-ci-release"
+    "generate-release": "eslint-generate-release",
+    "generate-alpharelease": "eslint-generate-prerelease alpha",
+    "generate-betarelease": "eslint-generate-prerelease beta",
+    "generate-rcrelease": "eslint-generate-prerelease rc",
+    "publish-release": "eslint-publish-release"
   },
   "repository": "eslint/eslint-visitor-keys",
   "keywords": [],


### PR DESCRIPTION
(refs https://github.com/eslint/eslint/issues/10631)

This updates `eslint-release` to allow the package to still be published from the Jenkins server now that we have 2FA enabled on the bot account.

Some changes are also needed on the Jenkins server -- I plan to make those changes after this is merged.