### PR TITLE
Fix: add "attribute" for JSXElement

### DIFF
--- a/lib/visitor-keys.json
+++ b/lib/visitor-keys.json
@@ -148,7 +148,8 @@
     "JSXElement": [
         "openingElement",
         "children",
-        "closingElement"
+        "closingElement",
+        "attributes"
     ],
     "JSXEmptyExpression": [],
     "JSXExpressionContainer": [


### PR DESCRIPTION
I noticed that this was missing. It's on JSXOpeneingElement, but not JSXElement.