### PR TITLE
Chore: added exported in exportAllDeclaration key

### DIFF
--- a/lib/visitor-keys.json
+++ b/lib/visitor-keys.json
@@ -66,6 +66,7 @@
     ],
     "EmptyStatement": [],
     "ExportAllDeclaration": [
+        "exported",
         "source"
     ],
     "ExportDefaultDeclaration": [


### PR DESCRIPTION
ref https://github.com/acornjs/acorn/blob/master/acorn-loose/src/statement.js#L366
ref https://github.com/eslint/eslint/issues/12629

currently `ExportAllDeclaration` type had only `source` as key, added `exported` to the key array