### PR TITLE
Breaking: drop support for Node <10

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lib"
   ],
   "engines": {
-    "node": ">=4"
+    "node": ">=10"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
This PR drops support for Node 8 now that it's no longer supported by the Node team.