### PR TITLE
Upgrade: eslint-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,10 @@
   "engines": {
     "node": ">=10"
   },
-  "dependencies": {},
   "devDependencies": {
     "eslint": "^4.7.2",
     "eslint-config-eslint": "^4.0.0",
-    "eslint-release": "^1.0.0",
+    "eslint-release": "^3.1.2",
     "mocha": "^3.5.3",
     "nyc": "^11.2.1",
     "opener": "^1.4.3"


### PR DESCRIPTION
Upgrade eslint-release so it releases can work with the `main` branch.