### PR TITLE
Build: Update branch reference in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
Switches from master to main in `ci.yml` to fix our CI which currently doesn't work.