### PR TITLE
Docs: Update the minimum nodeJS version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,7 @@ $ npm install eslint-visitor-keys
 
 ### Requirements
 
-Since eslint-visitor-keys v3:
-- [Node.js] 12.22.0 or 14.17.0 or later.
-
-Before:
-- [Node.js] 10.0.0 or later.
+- [Node.js] `^12.22.0`, `^14.17.0`, or `>=16.0.0`
 
 
 ## 📖 Usage

--- a/README.md
+++ b/README.md
@@ -17,7 +17,12 @@ $ npm install eslint-visitor-keys
 
 ### Requirements
 
+Since eslint-visitor-keys v3:
+- [Node.js] 12.22.0 or 14.17.0 or later.
+
+Before:
 - [Node.js] 10.0.0 or later.
+
 
 ## 📖 Usage
 
@@ -102,5 +107,5 @@ Welcome. See [ESLint contribution guidelines](https://eslint.org/docs/developer-
 
 
 [npm]: https://www.npmjs.com/
-[Node.js]: https://nodejs.org/en/
+[Node.js]: https://nodejs.org/
 [ESTree]: https://github.com/estree/estree


### PR DESCRIPTION
Also: no need to specify the /en/ in the nodejs.org URL, because the web server sets it automatically depending on the browser language.