### PR TITLE
feat: Bundle JSDoc-built TypeScript declaration file

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,15 @@
         "sourceType": "module",
         "ecmaVersion": 2020
     },
+    "settings": {
+        "jsdoc": {
+            "mode": "typescript",
+            "preferredTypes": {
+                "Object": "object",
+                "object<>": "Object"
+            }
+        }
+    },
     "overrides": [
         {
             "files": ["*.cjs"],

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,7 @@ function filterKey(key) {
 /**
  * Get visitor keys of a given node.
  * @param {Object} node The AST node to get keys.
- * @returns {string[]} Visitor keys of the node.
+ * @returns {readonly string[]} Visitor keys of the node.
  */
 export function getKeys(node) {
     return Object.keys(node).filter(filterKey);
@@ -33,11 +33,11 @@ export function getKeys(node) {
 // eslint-disable-next-line valid-jsdoc
 /**
  * Make the union set with `KEYS` and given keys.
- * @param {Object} additionalKeys The additional keys.
- * @returns {{ [type: string]: string[] | undefined }} The union set.
+ * @param {{ readonly [type: string]: ReadonlyArray<string> }} additionalKeys The additional keys.
+ * @returns {{ readonly [type: string]: ReadonlyArray<string> }} The union set.
  */
 export function unionWith(additionalKeys) {
-    const retv = Object.assign({}, KEYS);
+    const retv = /** @type {{ [type: string]: ReadonlyArray<string> }} */ (Object.assign({}, KEYS));
 
     for (const type of Object.keys(additionalKeys)) {
         if (Object.prototype.hasOwnProperty.call(retv, type)) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,6 @@
 import KEYS from "./visitor-keys.js";
 
 /**
- * @typedef {{ [type: string]: ReadonlyArray<string> }} VisitorKeysWritable
  * @typedef {{ readonly [type: string]: ReadonlyArray<string> }} VisitorKeys
  */
 
@@ -42,7 +41,9 @@ export function getKeys(node) {
  * @returns {VisitorKeys} The union set.
  */
 export function unionWith(additionalKeys) {
-    const retv = /** @type {VisitorKeysWritable} */ (Object.assign({}, KEYS));
+    const retv = /** @type {{
+        [type: string]: ReadonlyArray<string>
+    }} */ (Object.assign({}, KEYS));
 
     for (const type of Object.keys(additionalKeys)) {
         if (Object.prototype.hasOwnProperty.call(retv, type)) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,7 @@ function filterKey(key) {
 
 /**
  * Get visitor keys of a given node.
- * @param {Object} node The AST node to get keys.
+ * @param {object} node The AST node to get keys.
  * @returns {readonly string[]} Visitor keys of the node.
  */
 export function getKeys(node) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,8 +5,8 @@
 import KEYS from "./visitor-keys.js";
 
 /**
- * @typedef {{ [type: string]: ReadonlyArray<string> }} KeysStrict
- * @typedef {{ readonly [type: string]: ReadonlyArray<string> }} KeysStrictReadonly
+ * @typedef {{ [type: string]: ReadonlyArray<string> }} VisitorKeysWritable
+ * @typedef {{ readonly [type: string]: ReadonlyArray<string> }} VisitorKeys
  */
 
 // List to ignore keys.
@@ -38,11 +38,11 @@ export function getKeys(node) {
 // eslint-disable-next-line valid-jsdoc
 /**
  * Make the union set with `KEYS` and given keys.
- * @param {KeysStrictReadonly} additionalKeys The additional keys.
- * @returns {KeysStrictReadonly} The union set.
+ * @param {VisitorKeys} additionalKeys The additional keys.
+ * @returns {VisitorKeys} The union set.
  */
 export function unionWith(additionalKeys) {
-    const retv = /** @type {KeysStrict} */ (Object.assign({}, KEYS));
+    const retv = /** @type {VisitorKeysWritable} */ (Object.assign({}, KEYS));
 
     for (const type of Object.keys(additionalKeys)) {
         if (Object.prototype.hasOwnProperty.call(retv, type)) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,11 @@
  */
 import KEYS from "./visitor-keys.js";
 
+/**
+ * @typedef {{ [type: string]: ReadonlyArray<string> }} KeysStrict
+ * @typedef {{ readonly [type: string]: ReadonlyArray<string> }} KeysStrictReadonly
+ */
+
 // List to ignore keys.
 const KEY_BLACKLIST = new Set([
     "parent",
@@ -33,11 +38,11 @@ export function getKeys(node) {
 // eslint-disable-next-line valid-jsdoc
 /**
  * Make the union set with `KEYS` and given keys.
- * @param {{ readonly [type: string]: ReadonlyArray<string> }} additionalKeys The additional keys.
- * @returns {{ readonly [type: string]: ReadonlyArray<string> }} The union set.
+ * @param {KeysStrictReadonly} additionalKeys The additional keys.
+ * @returns {KeysStrictReadonly} The union set.
  */
 export function unionWith(additionalKeys) {
-    const retv = /** @type {{ [type: string]: ReadonlyArray<string> }} */ (Object.assign({}, KEYS));
+    const retv = /** @type {KeysStrict} */ (Object.assign({}, KEYS));
 
     for (const type of Object.keys(additionalKeys)) {
         if (Object.prototype.hasOwnProperty.call(retv, type)) {

--- a/lib/visitor-keys.js
+++ b/lib/visitor-keys.js
@@ -1,9 +1,9 @@
 /**
- * @typedef {import('./index.js').KeysStrictReadonly} KeysStrictReadonly
+ * @typedef {import('./index.js').VisitorKeys} VisitorKeys
  */
 
 /**
- * @type {KeysStrictReadonly}
+ * @type {VisitorKeys}
  */
 const KEYS = {
     AssignmentExpression: [

--- a/lib/visitor-keys.js
+++ b/lib/visitor-keys.js
@@ -1,5 +1,5 @@
 /**
- * @type {{ readonly [type: string]: ReadonlyArray<string> }}
+ * @type {{ readonly [type: string]: ReadonlyArray<string> | undefined }}
  */
 const KEYS = {
     AssignmentExpression: [

--- a/lib/visitor-keys.js
+++ b/lib/visitor-keys.js
@@ -1,9 +1,9 @@
 /**
- * @typedef {{ readonly [type: string]: ReadonlyArray<string> }} KeysLooseReadonly
+ * @typedef {import('./index.js').KeysStrictReadonly} KeysStrictReadonly
  */
 
 /**
- * @type {KeysLooseReadonly}
+ * @type {KeysStrictReadonly}
  */
 const KEYS = {
     AssignmentExpression: [

--- a/lib/visitor-keys.js
+++ b/lib/visitor-keys.js
@@ -1,5 +1,9 @@
 /**
- * @type {{ readonly [type: string]: ReadonlyArray<string> | undefined }}
+ * @typedef {{ readonly [type: string]: ReadonlyArray<string> }} KeysLooseReadonly
+ */
+
+/**
+ * @type {KeysLooseReadonly}
  */
 const KEYS = {
     AssignmentExpression: [

--- a/lib/visitor-keys.js
+++ b/lib/visitor-keys.js
@@ -1,3 +1,6 @@
+/**
+ * @type {{ readonly [type: string]: ReadonlyArray<string> }}
+ */
 const KEYS = {
     AssignmentExpression: [
         "left",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "exports": {
     ".": [
       {
-        "types": "./dist/index.d.ts",
         "import": "./lib/index.js",
         "require": "./dist/eslint-visitor-keys.cjs"
       },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "mocha": "^9.0.1",
     "opener": "^1.5.2",
     "rollup": "^2.52.1",
-    "typescript": "^4.6.0-dev.20220206"
+    "typescript": "^4.5.5"
   },
   "scripts": {
     "prepare": "npm run build && npm run tsc",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "mocha": "^9.0.1",
     "opener": "^1.5.2",
     "rollup": "^2.52.1",
+    "tsd": "^0.19.1",
     "typescript": "^4.5.5"
   },
   "scripts": {
@@ -41,7 +42,8 @@
     "build": "rollup -c && npm run tsc",
     "lint": "eslint .",
     "tsc": "tsc",
-    "test": "mocha tests/lib/**/*.cjs && c8 mocha tests/lib/**/*.js",
+    "tsd": "tsd",
+    "test": "mocha tests/lib/**/*.cjs && c8 mocha tests/lib/**/*.js && npm run tsd",
     "coverage": "c8 report --reporter lcov && opener coverage/lcov-report/index.html",
     "generate-release": "eslint-generate-release",
     "generate-alpharelease": "eslint-generate-prerelease alpha",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Constants and utilities about visitor keys to traverse AST.",
   "type": "module",
   "main": "dist/eslint-visitor-keys.cjs",
-  "types": "./dist/eslint-visitor.keys.d.ts",
+  "types": "./dist/eslint-visitor-keys.d.ts",
   "exports": {
     ".": [
       {
@@ -16,7 +16,7 @@
     "./package.json": "./package.json"
   },
   "files": [
-    "dist/eslint-visitor.keys.d.ts",
+    "dist/eslint-visitor-keys.d.ts",
     "dist/eslint-visitor-keys.cjs",
     "lib"
   ],

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Constants and utilities about visitor keys to traverse AST.",
   "type": "module",
   "main": "dist/eslint-visitor-keys.cjs",
+  "types": "./dist/eslint-visitor.keys.d.ts",
   "exports": {
     ".": [
       {
@@ -15,6 +16,7 @@
     "./package.json": "./package.json"
   },
   "files": [
+    "dist/eslint-visitor.keys.d.ts",
     "dist/eslint-visitor-keys.cjs",
     "lib"
   ],
@@ -30,12 +32,14 @@
     "eslint-release": "^3.2.0",
     "mocha": "^9.0.1",
     "opener": "^1.5.2",
-    "rollup": "^2.52.1"
+    "rollup": "^2.52.1",
+    "typescript": "^4.5.5"
   },
   "scripts": {
-    "prepare": "npm run build",
+    "prepare": "npm run build && npm run tsc",
     "build": "rollup -c",
     "lint": "eslint .",
+    "tsc": "tsc",
     "test": "mocha tests/lib/**/*.cjs && c8 mocha tests/lib/**/*.js",
     "coverage": "c8 report --reporter lcov && opener coverage/lcov-report/index.html",
     "generate-release": "eslint-generate-release",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "description": "Constants and utilities about visitor keys to traverse AST.",
   "type": "module",
   "main": "dist/eslint-visitor-keys.cjs",
-  "types": "./dist/eslint-visitor-keys.d.ts",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": [
       {
+        "types": "./dist/index.d.ts",
         "import": "./lib/index.js",
         "require": "./dist/eslint-visitor-keys.cjs"
       },
@@ -16,7 +17,8 @@
     "./package.json": "./package.json"
   },
   "files": [
-    "dist/eslint-visitor-keys.d.ts",
+    "dist/index.d.ts",
+    "dist/visitor-keys.d.ts",
     "dist/eslint-visitor-keys.cjs",
     "lib"
   ],
@@ -33,7 +35,7 @@
     "mocha": "^9.0.1",
     "opener": "^1.5.2",
     "rollup": "^2.52.1",
-    "typescript": "^4.5.5"
+    "typescript": "^4.6.0-dev.20220206"
   },
   "scripts": {
     "prepare": "npm run build && npm run tsc",

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "typescript": "^4.5.5"
   },
   "scripts": {
-    "prepare": "npm run build && npm run tsc",
-    "build": "rollup -c",
+    "prepare": "npm run build",
+    "build": "rollup -c && npm run tsc",
     "lint": "eslint .",
     "tsc": "tsc",
     "test": "mocha tests/lib/**/*.cjs && c8 mocha tests/lib/**/*.js",

--- a/test-d/index.test-d.ts
+++ b/test-d/index.test-d.ts
@@ -1,0 +1,45 @@
+import {expectType, expectAssignable} from 'tsd';
+
+import { KEYS, getKeys, unionWith, KeysStrict, KeysStrictReadonly } from "../lib/index.js";
+
+const assignmentExpression = {
+    type: "AssignmentExpression",
+    operator: "=",
+    left: {
+        type: "Identifier",
+        name: "a",
+        range: [
+            0,
+            1
+        ]
+    },
+    right: {
+        type: "Literal",
+        value: 5,
+        raw: "5",
+        range: [
+            4,
+            5
+        ]
+    },
+    range: [
+        0,
+        5
+    ]
+};
+
+expectType<{readonly [type: string]: readonly string[]}>(KEYS);
+
+expectType<readonly string[]>(getKeys(assignmentExpression));
+
+expectType<{readonly [type: string]: readonly string[]}>(unionWith({
+    TestInterface1: ["left", "right"],
+    TestInterface2: ["expression"]
+}));
+
+expectAssignable<KeysStrict>({
+    TestInterface1: ["left", "right"]
+});
+expectAssignable<KeysStrictReadonly>({
+    TestInterface1: ["left", "right"]
+});

--- a/test-d/index.test-d.ts
+++ b/test-d/index.test-d.ts
@@ -1,6 +1,6 @@
 import { expectType, expectAssignable, expectError } from 'tsd';
 
-import { KEYS, getKeys, unionWith, KeysStrict, KeysStrictReadonly } from "../lib/index.js";
+import { KEYS, getKeys, unionWith, VisitorKeysWritable, VisitorKeys } from "../lib/index.js";
 
 const assignmentExpression = {
     type: "AssignmentExpression",
@@ -49,12 +49,12 @@ const readonlyKeys: {
     TestInterface1: ["left", "right"]
 };
 
-expectAssignable<KeysStrict>(keys);
+expectAssignable<VisitorKeysWritable>(keys);
 
-expectAssignable<KeysStrictReadonly>(readonlyKeys);
+expectAssignable<VisitorKeys>(readonlyKeys);
 
 expectError(() => {
-    const erring: KeysStrict = {
+    const erring: VisitorKeysWritable = {
         TestInterface1: ["left", "right"]
     };
     erring.TestInterface1 = "badType";
@@ -62,7 +62,7 @@ expectError(() => {
 
 // https://github.com/SamVerschueren/tsd/issues/143
 // expectError(() => {
-//     const erring: KeysStrictReadonly = {
+//     const erring: VisitorKeys = {
 //         TestInterface1: ["left", "right"]
 //     };
 //     erring.TestInterface1 = ["badAttemptOverwrite"];

--- a/test-d/index.test-d.ts
+++ b/test-d/index.test-d.ts
@@ -1,6 +1,6 @@
 import { expectType, expectAssignable, expectError } from 'tsd';
 
-import { KEYS, getKeys, unionWith, VisitorKeysWritable, VisitorKeys } from "../lib/index.js";
+import { KEYS, getKeys, unionWith, VisitorKeysWritable, VisitorKeys } from "../";
 
 const assignmentExpression = {
     type: "AssignmentExpression",

--- a/test-d/index.test-d.ts
+++ b/test-d/index.test-d.ts
@@ -1,6 +1,8 @@
 import { expectType, expectAssignable, expectError } from 'tsd';
 
-import { KEYS, getKeys, unionWith, VisitorKeysWritable, VisitorKeys } from "../";
+import { KEYS, getKeys, unionWith, VisitorKeys } from "../";
+
+type VisitorKeysWritable = { [type: string]: ReadonlyArray<string> };
 
 const assignmentExpression = {
     type: "AssignmentExpression",

--- a/test-d/index.test-d.ts
+++ b/test-d/index.test-d.ts
@@ -2,8 +2,6 @@ import { expectType, expectAssignable, expectError } from 'tsd';
 
 import { KEYS, getKeys, unionWith, VisitorKeys } from "../";
 
-type VisitorKeysWritable = { [type: string]: ReadonlyArray<string> };
-
 const assignmentExpression = {
     type: "AssignmentExpression",
     operator: "=",
@@ -39,28 +37,13 @@ expectType<{readonly [type: string]: readonly string[]}>(unionWith({
     TestInterface2: ["expression"]
 }));
 
-const keys: {
-    [type: string]: readonly string[]
-} = {
-    TestInterface1: ["left", "right"]
-};
-
 const readonlyKeys: {
     readonly [type: string]: readonly string[]
 } = {
     TestInterface1: ["left", "right"]
 };
 
-expectAssignable<VisitorKeysWritable>(keys);
-
 expectAssignable<VisitorKeys>(readonlyKeys);
-
-expectError(() => {
-    const erring: VisitorKeysWritable = {
-        TestInterface1: ["left", "right"]
-    };
-    erring.TestInterface1 = "badType";
-});
 
 // https://github.com/SamVerschueren/tsd/issues/143
 // expectError(() => {

--- a/test-d/index.test-d.ts
+++ b/test-d/index.test-d.ts
@@ -1,4 +1,4 @@
-import {expectType, expectAssignable} from 'tsd';
+import { expectType, expectAssignable, expectError } from 'tsd';
 
 import { KEYS, getKeys, unionWith, KeysStrict, KeysStrictReadonly } from "../lib/index.js";
 
@@ -37,9 +37,33 @@ expectType<{readonly [type: string]: readonly string[]}>(unionWith({
     TestInterface2: ["expression"]
 }));
 
-expectAssignable<KeysStrict>({
+const keys: {
+    [type: string]: readonly string[]
+} = {
     TestInterface1: ["left", "right"]
-});
-expectAssignable<KeysStrictReadonly>({
+};
+
+const readonlyKeys: {
+    readonly [type: string]: readonly string[]
+} = {
     TestInterface1: ["left", "right"]
+};
+
+expectAssignable<KeysStrict>(keys);
+
+expectAssignable<KeysStrictReadonly>(readonlyKeys);
+
+expectError(() => {
+    const erring: KeysStrict = {
+        TestInterface1: ["left", "right"]
+    };
+    erring.TestInterface1 = "badType";
 });
+
+// https://github.com/SamVerschueren/tsd/issues/143
+// expectError(() => {
+//     const erring: KeysStrictReadonly = {
+//         TestInterface1: ["left", "right"]
+//     };
+//     erring.TestInterface1 = ["badAttemptOverwrite"];
+// });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es2020"],
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "module": "esnext",
     "resolveJsonModule": true,
     "allowJs": true,
@@ -12,7 +12,7 @@
     "emitDeclarationOnly": true,
     "strict": true,
     "target": "es5",
-    "outFile": "dist/eslint-visitor-keys.d.ts"
+    "outDir": "dist"
   },
   "include": ["lib/**/*.js"],
   "exclude": ["node_modules"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es2020"],
-    "moduleResolution": "nodenext",
+    "moduleResolution": "node",
     "module": "esnext",
     "resolveJsonModule": true,
     "allowJs": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "declarationMap": true,
     "emitDeclarationOnly": true,
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "outDir": "dist"
   },
   "include": ["lib/**/*.js"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "lib": ["es2020"],
+    "moduleResolution": "node",
+    "module": "esnext",
+    "resolveJsonModule": true,
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "strict": true,
+    "target": "es5",
+    "outFile": "dist/eslint-visitor-keys.d.ts"
+  },
+  "include": ["lib/**/*.js"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
In the process of preparing ESLint for more type awareness, I figured we might avoid the need for an external `@types` package with the ability to maintain the types here (and to generate it out of JSDoc where possible as per https://github.com/eslint/espree/issues/529#issuecomment-1012561247 ).

One item I noticed in comparing with the declaration file in `@types/eslint-visitor-keys` is that `undefined` was allowed on properties, e.g.:

```ts
export interface VisitorKeys {
    readonly [type: string]: ReadonlyArray<string> | undefined;
}
```

In the PR, I have sought to preserve this ability, but I noticed that with the `unionWith` function, the additional keys argument couldn't include such properties as the current code would fail.