### PR TITLE
docs: update badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/eslint-visitor-keys.svg)](https://www.npmjs.com/package/eslint-visitor-keys)
 [![Downloads/month](https://img.shields.io/npm/dm/eslint-visitor-keys.svg)](http://www.npmtrends.com/eslint-visitor-keys)
-[![Build Status](https://travis-ci.org/eslint/eslint-visitor-keys.svg?branch=master)](https://travis-ci.org/eslint/eslint-visitor-keys)
-[![Dependency Status](https://david-dm.org/eslint/eslint-visitor-keys.svg)](https://david-dm.org/eslint/eslint-visitor-keys)
+[![Build Status](https://github.com/eslint/eslint-visitor-keys/workflows/CI/badge.svg)](https://github.com/eslint/eslint-visitor-keys/actions)
 
 Constants and utilities about visitor keys to traverse AST.
 


### PR DESCRIPTION
* Updates the Build Status badge, from Travis to GitHub Actions.
* Removes the Dependency Status badge. `david-dm.org` seems to be unavailable for a while, and in other projects we don't have dependency badges so I just removed this one.