### PR TITLE
chore: set up release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           release-type: node
           package-name: 'eslint-visitor-keys'
-          pull-request-title-pattern: 'chore: release${component} ${version}'
+          pull-request-title-pattern: 'chore: release ${version}'
           changelog-types: >
             [
               { "type": "feat", "section": "Features", "hidden": false },

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,55 @@
+on:
+  push:
+    branches:
+      - main
+name: release-please
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        id: release
+        with:
+          release-type: node
+          package-name: 'eslint-visitor-keys'
+          pull-request-title-pattern: 'chore: release${component} ${version}'
+          changelog-types: >
+            [
+              { "type": "feat", "section": "Features", "hidden": false },
+              { "type": "fix", "section": "Bug Fixes", "hidden": false },
+              { "type": "docs", "section": "Documentation", "hidden": false },
+              { "type": "build", "section": "Build Related", "hidden": false },
+              { "type": "chore", "section": "Chores", "hidden": false },
+              { "type": "perf", "section": "Chores", "hidden": false },
+              { "type": "ci", "section": "Chores", "hidden": false },
+              { "type": "refactor", "section": "Chores", "hidden": false },
+              { "type": "test", "section": "Chores", "hidden": false }
+            ]
+      - uses: actions/checkout@v3
+        if: ${{ steps.release.outputs.release_created }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+          registry-url: https://registry.npmjs.org
+        if: ${{ steps.release.outputs.release_created }}
+      - run: npm install
+        if: ${{ steps.release.outputs.release_created }}
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        if: ${{ steps.release.outputs.release_created }}
+      - run: 'npx @humanwhocodes/tweet "eslint-visitor-keys ${{ steps.release.outputs.tag_name }} has been released: ${{ steps.release.outputs.html_url }}"'
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          TWITTER_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}
+          TWITTER_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_SECRET }}
+          TWITTER_ACCESS_TOKEN_KEY: ${{ secrets.TWITTER_ACCESS_TOKEN_KEY }}
+          TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+      - run: 'npx @humanwhocodes/toot "eslint-visitor-keys ${{ steps.release.outputs.tag_name }} has been released: ${{ steps.release.outputs.html_url }}"'
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          MASTODON_ACCESS_TOKEN: ${{ secrets.MASTODON_ACCESS_TOKEN }}
+          MASTODON_HOST: ${{ secrets.MASTODON_HOST }}


### PR DESCRIPTION
Sets up release-please.

The `release-please.yml` file is copied from the espree repo + I added an `npm install` step (same as in https://github.com/eslint/espree/pull/573)  

Additional non-code setup:

- [x] Update [organization Actions secrets][1] to give this repository access to `NPM_TOKEN`,  `MASTODON_ACCESS_TOKEN` and the four `TWITTER_*` secrets.
- [x] Update [repository Actions settings][2] to "Allow GitHub Actions to create and approve pull requests". (this was already enabled!)
- [x] Update [npm package settings][3] to "Require two-factor authentication **or** an automation or granular access token"

[1]: https://github.com/organizations/eslint/settings/secrets/actions
[2]: https://github.com/eslint/eslint-visitor-keys/settings/actions
[3]: https://www.npmjs.com/package/eslint-visitor-keys/access

Please double-check the `release-please.yml` file and all non-code setup items.