### PR TITLE
docs: remove `release` script reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ Welcome. See [ESLint contribution guidelines](https://eslint.org/docs/developer-
 - `npm test` runs tests and measures code coverage.
 - `npm run lint` checks source codes with ESLint.
 - `npm run coverage` opens the code coverage report of the previous test with your default browser.
-- `npm run release` publishes this package to [npm] registry.
 
 
 [npm]: https://www.npmjs.com/


### PR DESCRIPTION
Removes `npm run release` command from README.md as we don't have that script and we're now using release-please.