### PR TITLE
ci: generate provenance statements when release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,6 +9,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     steps:
       - uses: google-github-actions/release-please-action@v3
         id: release
@@ -37,7 +38,7 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
       - run: npm install
         if: ${{ steps.release.outputs.release_created }}
-      - run: npm publish
+      - run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
Using `npm publish --provenance`, you can show the provenance in npmjs, making the whole process more transparent and easier to audit.

<img width="813" alt="image" src="https://github.com/eslint/espree/assets/45708948/4e5061d5-416e-45bf-bc5c-bcd22a15b324">

You can see the provenance at [semver on npmjs](https://www.npmjs.com/package/semver)

Ref [Generating provenance statements | npm Docs](https://docs.npmjs.com/generating-provenance-statements)

---

For the original PR, check out https://github.com/eslint/espree/pull/579