### PR TITLE
chore: update `typedef` in build keys template

### DIFF
--- a/tools/build-keys-from-ts.js
+++ b/tools/build-keys-from-ts.js
@@ -31,7 +31,7 @@ const { promises: { writeFile } } = fs;
         "./lib/visitor-keys.js",
         // eslint-disable-next-line indent -- Readability
 `/**
- * @typedef {import('./index.js').VisitorKeys} VisitorKeys
+ * @typedef {{ readonly [type: string]: ReadonlyArray<string> }} VisitorKeys
  */
 
 /**


### PR DESCRIPTION
Updates script that generates `visitor-keys.js` with the change from https://github.com/eslint/eslint-visitor-keys/pull/47. Otherwise, running this script would revert the change.