### PR TITLE
chore: Add back add-to-triage

### DIFF
--- a/.github/workflows/add-to-triage.yml
+++ b/.github/workflows/add-to-triage.yml
@@ -4,9 +4,6 @@ on:
   issues:
     types:
       - opened
-  pull_request:
-    types:
-      - opened
 
 jobs:
   add-to-project:

--- a/.github/workflows/add-to-triage.yml
+++ b/.github/workflows/add-to-triage.yml
@@ -10,7 +10,7 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.4.0
+      - uses: actions/add-to-project@v0.5.0
         with:
           project-url: https://github.com/orgs/eslint/projects/3
           github-token: ${{ secrets.PROJECT_BOT_TOKEN }}

--- a/.github/workflows/add-to-triage.yml
+++ b/.github/workflows/add-to-triage.yml
@@ -1,0 +1,21 @@
+name: Add to Triage
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.4.0
+        with:
+          project-url: https://github.com/orgs/eslint/projects/3
+          github-token: ${{ secrets.PROJECT_BOT_TOKEN }}
+          labeled: "triage:no"
+          label-operator: NOT


### PR DESCRIPTION
Because we can only have a limited number of auto-add repos on the triage project, we still need this workflow.

Reverts eslint/eslint-visitor-keys#56